### PR TITLE
Change keyword obfuscation naming convention

### DIFF
--- a/soscleaner/soscleaner.py
+++ b/soscleaner/soscleaner.py
@@ -1091,7 +1091,7 @@ class SOSCleaner:
                                 keyword = keyword.rstrip()
                                 if len(keyword) > 1:
                                     if self.kw_db.get(keyword) is None:  # no duplicates
-                                        o_kw = "keyword%s" % self.kw_count
+                                        o_kw = "obfuscatedkeyword%s" % self.kw_count
                                         self.kw_db[keyword] = o_kw
                                         self.logger.con_out("Added Obfuscated Keyword from Keywords File - %s > %s", keyword, o_kw)
                                         self.kw_count += 1
@@ -1104,7 +1104,7 @@ class SOSCleaner:
             if len(self.keywords) > 0:
                 for kw in self.keywords:
                     if len(kw) > 1:  # no single digit keywords
-                        o_kw = "keyword%s" % self.kw_count
+                        o_kw = "obfuscatedkeyword%s" % self.kw_count
                         self.kw_db[kw] = o_kw
                         self.logger.con_out("Added obfuscated keyword - %s > %s", kw, o_kw)
                         self.kw_count += 1


### PR DESCRIPTION
Making it consistent with actual pattern used for hostname and user
Making it also more obvious for user and vendor who may look a file
with keyword obfuscation.

Fix #103

Signed-off-by: Eric Desrochers eric.desrochers@canonical.com