### PR TITLE
[config_file] Renaming config_file and changing its location

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -48,7 +48,7 @@ The default way to use SOSCleaner is using the command-line application of the s
 
 Using a config file
 --------------------
-If you find yourself having to use additional command line options a lot, you can create a config file at ``/etc/sysconfig/soscleaner`` to handle these default values for you. A sample config file:
+If you find yourself having to use additional command line options a lot, you can create a config file at ``/etc/soscleaner.conf`` to handle these default values for you. A sample config file:
 
 .. code-block:: ini
   :linenos:

--- a/soscleaner/soscleaner.py
+++ b/soscleaner/soscleaner.py
@@ -88,7 +88,7 @@ class SOSCleaner:
         self.user_db = dict()
         self.user_count = 1
         self._prime_userdb()
-        self.config_file = '/etc/sysconfig/soscleaner'
+        self.config_file = '/etc/soscleaner.conf'
         self._read_early_config_options()
         self.obfuscate_macs = True  # issue #98
 


### PR DESCRIPTION
Renaming and changing config_file in order to be more other
linux distributions friendly for OSes with not
/etc/sysconfig directory.

/etc/soscleaner.conf reflects what sosreport does with
/etc/sos.conf.

Fix #100

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>