### PR TITLE
Fix spelling mistakes and pycodestyle warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Purpose
 -------
 SOSCleaner is a tool to consistently obfuscate sensitive information in large datasets like Red Hat sosreports. It works on any data set, from 1 file to thousands.
 
-Documenation
+Documentation
 ----------------
-Documenation has been moved to ReadTheDocs.
+Documentation has been moved to ReadTheDocs.
 
 https://soscleaner.readthedocs.io
 

--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -23,7 +23,7 @@ The default way to use SOSCleaner is using the command-line application of the s
                           additional domain to obfuscate (optional). use a flag
                           for each additional domain
     -f FILES, --file=FILES
-                          addtional files to be analyzed in addition to or in
+                          additional files to be analyzed in addition to or in
                           exception of sosreport
     -q, --quiet           disable output to STDOUT
     -k KEYWORD, --keyword=KEYWORD

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -33,7 +33,7 @@ We've just started using `gitchangelog <https://pypi.org/project/gitchangelog/>`
 
       Is WHO is concerned by the change.
 
-      'dev'  is for developpers (API changes, refactors...)
+      'dev'  is for developers (API changes, refactors...)
       'usr'  is for final users (UI changes)
       'pkg'  is for packagers   (packaging changes)
       'test' is for testers     (test only related changes)

--- a/scripts/soscleaner
+++ b/scripts/soscleaner
@@ -16,7 +16,7 @@ def main():
                             help="additional domain to obfuscate (optional). use a flag for each additional domain",
                             metavar="DOMAIN")
     parser.add_option("-f", "--file", action="append", default=[], dest="files",
-                            help="addtional files to be analyzed in addition to or in exception of sosreport",
+                            help="additional files to be analyzed in addition to or in exception of sosreport",
                             metavar="FILES")
     parser.add_option("-q", "--quiet", action="store_true", default=False, dest='quiet',
                             help="disable output to STDOUT",

--- a/soscleaner/soscleaner.py
+++ b/soscleaner/soscleaner.py
@@ -440,7 +440,7 @@ class SOSCleaner:
 
                 # first, we get out the unique user entries
                 for line in data:
-                    if len(line) > 1:  # there are some blank lines at the end of the last ouput
+                    if len(line) > 1:  # there are some blank lines at the end of the last output
                         sorted_users.append(line.split()[0])
 
                 # then we add them to the obfuscation database
@@ -666,7 +666,7 @@ class SOSCleaner:
                 # using this lambda to create a valid randomized mac address is
                 # documented at https://www.commandlinefu.com/commands/view/7245/generate-random-valid-mac-addresses
                 # many thanks for putting that little thought together
-                o_mac = ':'.join(['%02x'%x for x in imap(lambda x:randint(0, 255), range(6))])
+                o_mac = ':'.join(['%02x' % x for x in imap(lambda x:randint(0, 255), range(6))])
                 self.logger.debug("Creating new obfuscated MAC address: %s > %s", mac, o_mac)
                 self.mac_db[mac] = o_mac
 
@@ -750,7 +750,7 @@ class SOSCleaner:
         Each label can be a maximum of 63 characters
         With 4th, 5th, 6th level domains being more the norm today, I wanted to take as
         broad an interpretation of a domain as I could. SO:
-        seperated by a word boundary
+        separated by a word boundary
         the lower domains can be a max of 190 characters, not including dots
         any valid domain character is allowed (alpha, digit, dash)
         the top level domain can be up to 63 characters, and not contain numbers


### PR DESCRIPTION
soscleaner/soscleaner.py:669:41: E228 missing whitespace around modulo operator

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>