### PR TITLE
Fix bandit report B110 try_except_pass

### DIFF
--- a/soscleaner/soscleaner.py
+++ b/soscleaner/soscleaner.py
@@ -133,7 +133,7 @@ class SOSCleaner:
             else:
                 return True
 
-        except Exception:  # pragma: no cover
+        except OSError as e: # pragma: no cover
             pass
 
     def _read_later_config_options(self):


### PR DESCRIPTION
>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
   Severity: Low   Confidence: High
   Location: soscleaner/soscleaner.py:136
135
136	        except Exception:  # pragma: no cover
137	            pass

https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html

Fix: #112

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>