### PR TITLE
Drop the use of eval

### DIFF
--- a/soscleaner/soscleaner.py
+++ b/soscleaner/soscleaner.py
@@ -246,7 +246,7 @@ class SOSCleaner:
     def _start_logging(self, filename):
         """Creates the logging objects and starts a logging instance."""
         # will get the logging instance going
-        loglevel_config = 'logging.%s' % self.loglevel
+        loglevel_config = '%s' % self.loglevel
 
         # i'd like the stdout to be under another logging name than 'con_out'
         console_log_level = 25  # between INFO and WARNING
@@ -260,7 +260,7 @@ class SOSCleaner:
         logging.Logger.con_out = con_out
 
         logging.basicConfig(filename=filename,
-                            level=eval(loglevel_config),
+                            level=logging.getLevelName(loglevel_config),
                             format='%(asctime)s %(name)s %(levelname)s: %(message)s',
                             datefmt='%m-%d %H:%M:%S'
                             )


### PR DESCRIPTION
Using getLevelName might be more appropriate in this situation.

Bandit tool report:
--------------------------------------------------
>> Issue: [B307:blacklist] Use of possibly insecure function - consider using safer ast.literal_eval.
   Severity: Medium   Confidence: High
   Location: soscleaner/soscleaner.py:263
262	        logging.basicConfig(filename=filename,
263	                            level=eval(loglevel_config),
264	                            format='%(asctime)s %(name)s %(levelname)s: %(message)s',
--------------------------------------------------

Fix: #114

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>