### PR TITLE
Extract archive with subprocess.Popen instead of os.system

### DIFF
--- a/soscleaner/soscleaner.py
+++ b/soscleaner/soscleaner.py
@@ -33,6 +33,7 @@ from ipaddr import IPv4Network, IPv4Address, IPv6Network, IPv6Address
 from itertools import imap
 from random import randint
 import ConfigParser
+import subprocess
 
 
 class SOSCleaner:
@@ -324,7 +325,7 @@ class SOSCleaner:
                             self.logger.info('Data Source Appears To Be LZMA Encrypted Data - decompressing into %s', self.origin_path)
                             self.logger.info('LZMA Hack - Creating %s', self.origin_path)
                             os.system('mkdir %s' % self.origin_path)
-                            os.system('tar -xJf %s -C %s' % (path, self.origin_path))
+                            subprocess.Popen(["tar", "-xJf", path, "-C", self.origin_path]).wait()
                             return_path = os.path.join(self.origin_path, os.listdir(self.origin_path)[0])
 
                             return return_path


### PR DESCRIPTION
--------------
>> Issue: [B605:start_process_with_a_shell] Starting a process with a shell, possible injection detected, security issue.
   Severity: High   Confidence: High
   Location: soscleaner/soscleaner.py:327
327	                            os.system('tar -xJf %s -C %s' % (path, self.origin_path))
328	                            return_path = os.path.join(self.origin_path, os.listdir(self.origin_path)[0])
--------------

Fix:#117

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>