### PR TITLE
Ignore Username column to avoid soscleaner to treat it like a username.

### DIFF
--- a/soscleaner/soscleaner.py
+++ b/soscleaner/soscleaner.py
@@ -493,7 +493,8 @@ class SOSCleaner:
 
         # users and entries that we don't want to add that show up in last
         ignored_users = ('landscape', 'lxd', 'reboot',
-                         'shutdown', 'ubuntu', 'wtmp')
+                         'shutdown', 'ubuntu', 'wtmp',
+                         'Username')
         # we're not calling this function from an option on the cli, we're just running it as part of __init__
 
         try:


### PR DESCRIPTION
lastlog output:
Username         Port     From             Latest
root                                       **Never logged in**
daemon                                     **Never logged in**
bin                                        **Never logged in**

and then soscleaner split()[0]

Username
root
daemon
bin

Soscleaner never exclude Username and consider it like a user when it's not.

Fix: #130

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>